### PR TITLE
Add felixs-test to Backstage Software Catalog

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -1,0 +1,10 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: felixs-test
+  annotations:
+    github.com/project-slug: 'spotify-portal-demo/felixs-test'
+spec:
+  type: other
+  lifecycle: experimental
+  owner: eagles


### PR DESCRIPTION

## TL;DR

This pull request registers felixs-test, as a component in our Backstage Software Catalog.
It lists our team, eagles, as the owners of this component.
After this file has merged, you can view this component in Backstage Software Catalog here: → https://goats.spotifyportal.com/catalog

## What is Portal?

[Portal](https://backstage.spotify.com/products/portal) is an internal developer portal based on [Backstage](https://backstage.io/). It's goal is making developers' lives easier. Portal unifies all your infrastructure tooling, services, and documentation to create a streamlined development environment from end to end.
